### PR TITLE
bump octokit to 10.0

### DIFF
--- a/src/IssueInProgressDaysLabeler.Model/IssueInProgressDaysLabeler.Model.csproj
+++ b/src/IssueInProgressDaysLabeler.Model/IssueInProgressDaysLabeler.Model.csproj
@@ -14,7 +14,7 @@
       <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
       <PackageReference Include="Mindbox.WorkingCalendar" Version="1.0.17" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-      <PackageReference Include="Octokit" Version="2.0.1" />
+      <PackageReference Include="Octokit" Version="10.0.0" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Бампаем octokit до 10.0  
Там [критический баг](https://github.com/octokit/octokit.net/issues/2889), из-за которого [не меняются](https://mindbox.slack.com/archives/C04N9EA6YN5/p1709199122374979) лейблы у карточек